### PR TITLE
Discourage using <owners>

### DIFF
--- a/Score/Validations/NuGetConventions/NuspecValidator.cs
+++ b/Score/Validations/NuGetConventions/NuspecValidator.cs
@@ -27,9 +27,10 @@ namespace Score.Validations.NuGetConventions
                 .WithName("<repository> is missing")
                 .WithMessage("Add a <repository> to your package.");
             
-            RuleFor(x => x.NuspecReader.GetOwners()).NotEmpty()
-                .WithName("<owners> is missing.")
-                .WithMessage("Add <owners> to your .nuspec");
+            RuleFor(x => x.NuspecReader.GetOwners()).Empty()
+                .WithName("<owners> is deprecated. Use <authors> instead.")
+                .WithMessage("The <owners> element is not recognized by NuGet.org. Owners are typically managed by in package source instead of in package metadata.");
+
             RuleFor(x => x.NuspecReader.GetCopyright()).NotEmpty()
                 .WithName("<copyright> is missing.")
                 .WithMessage("Add <copyright> to your .nuspec");

--- a/Score/Validations/NuGetConventions/NuspecValidator.cs
+++ b/Score/Validations/NuGetConventions/NuspecValidator.cs
@@ -29,7 +29,7 @@ namespace Score.Validations.NuGetConventions
             
             RuleFor(x => x.NuspecReader.GetOwners()).Empty()
                 .WithName("<owners> is deprecated. Use <authors> instead.")
-                .WithMessage("The <owners> element is not recognized by NuGet.org. Owners are typically managed by in package source instead of in package metadata.");
+                .WithMessage("The <owners> element is not recognized by NuGet.org. Owners are typically managed in the package source instead of in the .nuspec.");
 
             RuleFor(x => x.NuspecReader.GetCopyright()).NotEmpty()
                 .WithName("<copyright> is missing.")


### PR DESCRIPTION
Per https://twitter.com/_JonDouglas/status/1368256288354877440
Documentation: https://docs.microsoft.com/en-us/nuget/reference/nuspec#owners

Appearance for the most popular package with owners ([System.Threading.Thread 4.0.0](https://www.nuget.org/packages/System.Threading.Thread/4.0.0)):
![image](https://user-images.githubusercontent.com/94054/110231472-c47ebb00-7ecc-11eb-9118-18c7e85c6414.png)

We're already headed in the right direction:
![image](https://user-images.githubusercontent.com/94054/110231525-145d8200-7ecd-11eb-95b0-9b78294347ea.png)
